### PR TITLE
docs: wrap the control, not the whole field, in the Input Fields demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,15 @@ A border that waits for the interaction instead of looping. On a form field `foc
 follows the focus of the control inside it, so there is no state to wire up:
 
 ```tsx
-<BorderAnimate variant="draw" trigger="focus-within" radius="sm">
-  <TextInput label="Email" placeholder="you@example.com" />
-</BorderAnimate>
+<Input.Wrapper label="Email">
+  <BorderAnimate variant="draw" trigger="focus-within" radius="sm">
+    <Input w="100%" placeholder="you@example.com" />
+  </BorderAnimate>
+</Input.Wrapper>
 ```
+
+Wrap the control, not the whole field: a `TextInput` is an `Input.Wrapper`, so wrapping it would put the
+border around the label too.
 
 ## Sponsor
 

--- a/docs/demos/BorderAnimate.demo.withInput.tsx
+++ b/docs/demos/BorderAnimate.demo.withInput.tsx
@@ -1,34 +1,42 @@
 import { BorderAnimate } from '@gfazioli/mantine-border-animate';
-import { Stack, TextInput } from '@mantine/core';
+import { Input, Stack } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 
 const code = `import { BorderAnimate } from '@gfazioli/mantine-border-animate';
-import { Stack, TextInput } from '@mantine/core';
+import { Input, Stack } from '@mantine/core';
 
 function Demo() {
   return (
     <Stack w={300}>
-      {/* focus-within follows the focus of anything inside the wrapper */}
-      <BorderAnimate trigger="focus-within" radius="sm" borderWidth="sm">
-        <TextInput w="100%" label="Email" placeholder="you@example.com" />
-      </BorderAnimate>
+      {/* Wrap the control, not the whole field: with a TextInput the border would
+          enclose the label too. Input.Wrapper keeps the label outside and still
+          passes its id down to Input through context, so clicking it focuses the field. */}
+      <Input.Wrapper label="Email">
+        <BorderAnimate trigger="focus-within" radius="sm" borderWidth="sm">
+          <Input w="100%" placeholder="you@example.com" />
+        </BorderAnimate>
+      </Input.Wrapper>
 
       {/* The draw variant turns that into a border that writes itself */}
-      <BorderAnimate
-        variant="draw"
-        trigger="focus-within"
-        radius="sm"
-        borderWidth="sm"
-        colorFrom="teal.4"
-        colorTo="teal.6"
-      >
-        <TextInput w="100%" label="Full name" placeholder="Click into the field" />
-      </BorderAnimate>
+      <Input.Wrapper label="Full name">
+        <BorderAnimate
+          variant="draw"
+          trigger="focus-within"
+          radius="sm"
+          borderWidth="sm"
+          colorFrom="teal.4"
+          colorTo="teal.6"
+        >
+          <Input w="100%" placeholder="Click into the field" />
+        </BorderAnimate>
+      </Input.Wrapper>
 
       {/* Always on, for a field that needs attention right now */}
-      <BorderAnimate variant="pulse" radius="sm" duration={2} colorFrom="orange.6" colorTo="red.6">
-        <TextInput w="100%" label="Verification code" placeholder="6 digits" />
-      </BorderAnimate>
+      <Input.Wrapper label="Verification code">
+        <BorderAnimate variant="pulse" radius="sm" duration={2} colorFrom="orange.6" colorTo="red.6">
+          <Input w="100%" placeholder="6 digits" />
+        </BorderAnimate>
+      </Input.Wrapper>
     </Stack>
   );
 }
@@ -37,27 +45,41 @@ function Demo() {
 function Demo() {
   return (
     <Stack w={300}>
-      {/* focus-within follows the focus of anything inside the wrapper */}
-      <BorderAnimate trigger="focus-within" radius="sm" borderWidth="sm">
-        <TextInput w="100%" label="Email" placeholder="you@example.com" />
-      </BorderAnimate>
+      {/* Wrap the control, not the whole field: with a TextInput the border would
+          enclose the label too. Input.Wrapper keeps the label outside and still
+          passes its id down to Input through context, so clicking it focuses the field. */}
+      <Input.Wrapper label="Email">
+        <BorderAnimate trigger="focus-within" radius="sm" borderWidth="sm">
+          <Input w="100%" placeholder="you@example.com" />
+        </BorderAnimate>
+      </Input.Wrapper>
 
       {/* The draw variant turns that into a border that writes itself */}
-      <BorderAnimate
-        variant="draw"
-        trigger="focus-within"
-        radius="sm"
-        borderWidth="sm"
-        colorFrom="teal.4"
-        colorTo="teal.6"
-      >
-        <TextInput w="100%" label="Full name" placeholder="Click into the field" />
-      </BorderAnimate>
+      <Input.Wrapper label="Full name">
+        <BorderAnimate
+          variant="draw"
+          trigger="focus-within"
+          radius="sm"
+          borderWidth="sm"
+          colorFrom="teal.4"
+          colorTo="teal.6"
+        >
+          <Input w="100%" placeholder="Click into the field" />
+        </BorderAnimate>
+      </Input.Wrapper>
 
       {/* Always on, for a field that needs attention right now */}
-      <BorderAnimate variant="pulse" radius="sm" duration={2} colorFrom="orange.6" colorTo="red.6">
-        <TextInput w="100%" label="Verification code" placeholder="6 digits" />
-      </BorderAnimate>
+      <Input.Wrapper label="Verification code">
+        <BorderAnimate
+          variant="pulse"
+          radius="sm"
+          duration={2}
+          colorFrom="orange.6"
+          colorTo="red.6"
+        >
+          <Input w="100%" placeholder="6 digits" />
+        </BorderAnimate>
+      </Input.Wrapper>
     </Stack>
   );
 }

--- a/docs/docs.mdx
+++ b/docs/docs.mdx
@@ -215,6 +215,8 @@ Add animated borders to buttons to make them stand out. A call to action can ani
 
 `trigger="focus-within"` is the answer here: the wrapper follows the focus of the control inside it, so the border lights up exactly when the field is active — no state to wire up, and it keeps working with the keyboard. Combine it with `variant="draw"` and the border writes itself around the field on focus. A field that needs attention before it is touched is the one case where an always-running animation is right.
 
+Wrap the **control**, not the whole field. A Mantine `TextInput` is an `Input.Wrapper` — label, description, input and error in one box — so wrapping it puts the animated border around the label as well, and the `radius` you set to match the input no longer traces its corners. Use `Input.Wrapper` for the label and let `BorderAnimate` hold only the `Input`. The label still points at the real control: `Input` reads the id from `Input.Wrapper` through React context, which does not care how deep the consumer sits.
+
 <Demo data={demos.withInput} />
 
 ### Alerts and Notifications


### PR DESCRIPTION
Closes #33.

## The problem

`BorderAnimate` positions its border against its own root, and the demo wrapped a whole `TextInput`. A Mantine `TextInput` is an `Input.Wrapper` — label, description, control and error in one box — so the animated border enclosed the label as well as the field. The `radius="sm"` set to match the input was tracing a much taller box, so its corners no longer lined up with the corners of the field they were supposed to follow.

## The change

`Input.Wrapper` holds the label, `BorderAnimate` holds only the `Input`:

```tsx
<Input.Wrapper label="Email">
  <BorderAnimate trigger="focus-within" radius="sm" borderWidth="sm">
    <Input w="100%" placeholder="you@example.com" />
  </BorderAnimate>
</Input.Wrapper>
```

Applied to all three examples, to the `README.md` snippet, and `docs.mdx` gained a paragraph saying where the label goes and why. No component change — the component was doing exactly what it was told.

## Verified in a browser, not by eye

| Check | Result |
|---|---|
| Border height vs input height | **deltaH 0.0px** on all three fields (both 300x36) |
| Label inside the border root? | **false** on all three |
| `label[for]` === `input.id` | **true** on all three |
| Click the label focuses the input | **true** (`document.activeElement === input`) |

That last row is the one that mattered: it is what would have turned this from an improvement into an accessibility regression. `Input` reads the id from `Input.Wrapper` through React context, and context does not care how deep the consumer sits, so inserting `BorderAnimate` between them keeps the association.

## One defect found and fixed mid-review

The first version dropped `w="100%"` (the old demo had it on `TextInput`). The border then sat at the wrapper width of 300px while the bare `Input` stayed at its intrinsic 180px, so the border overhung the field on the right — clearly visible on the always-on pulse example. Restored on all three.

## Test plan
- [x] `yarn test` passes
- [x] `yarn docs:build` passes with `docs/.next` removed first
- [x] Geometry and label association measured in Chrome

## Note

Docs-only, so no npm release is needed — a `yarn docs:deploy` is enough. The `README.md` correction, however, only reaches the npm package page at the next release, since `package/README.md` is copied from the root README at release time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated input field examples to place labels outside animated borders.
  * Clarified that animated borders follow the input’s corners without enclosing its label.
  * Added guidance on wrapping plain inputs with `Input.Wrapper` for proper labeling and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->