### PR TITLE
docs: make the focus-within trigger card parallel to its siblings

### DIFF
--- a/docs/demos/BorderAnimate.demo.withTrigger.tsx
+++ b/docs/demos/BorderAnimate.demo.withTrigger.tsx
@@ -1,9 +1,9 @@
 import { BorderAnimate } from '@gfazioli/mantine-border-animate';
-import { Flex, Paper, Text, TextInput } from '@mantine/core';
+import { Flex, Input, Paper, Text } from '@mantine/core';
 import { MantineDemo } from '@mantinex/demo';
 
 const code = `import { BorderAnimate } from '@gfazioli/mantine-border-animate';
-import { Flex, Paper, Text, TextInput } from '@mantine/core';
+import { Flex, Input, Paper, Text } from '@mantine/core';
 
 function Demo() {
   return (
@@ -17,8 +17,11 @@ function Demo() {
       </BorderAnimate>
 
       {/* Follows the focus of anything inside, so it works with real form controls */}
-      <BorderAnimate trigger="focus-within" borderWidth="sm" radius="sm">
-        <TextInput w={190} placeholder="Click into the field" label='trigger="focus-within"' />
+      <BorderAnimate trigger="focus-within" borderWidth="sm">
+        <Paper radius="md" p="md" w={190}>
+          <Text fw={600}>trigger="focus-within"</Text>
+          <Input mt="xs" placeholder="Click into the field" />
+        </Paper>
       </BorderAnimate>
 
       {/* Animates only while the component is on screen */}
@@ -47,8 +50,11 @@ function Demo() {
       </BorderAnimate>
 
       {/* Follows the focus of anything inside, so it works with real form controls */}
-      <BorderAnimate trigger="focus-within" borderWidth="sm" radius="sm">
-        <TextInput w={190} placeholder="Click into the field" label='trigger="focus-within"' />
+      <BorderAnimate trigger="focus-within" borderWidth="sm">
+        <Paper radius="md" p="md" w={190}>
+          <Text fw={600}>trigger="focus-within"</Text>
+          <Input mt="xs" placeholder="Click into the field" />
+        </Paper>
       </BorderAnimate>
 
       {/* Animates only while the component is on screen */}


### PR DESCRIPTION
Follow-up to #33, which I closed after fixing only the Input Fields demo. The same shape existed in a second place and I missed it — it surfaced while checking the deployed page for leftover `TextInput` usages.

## The problem

In the Triggers demo the `focus-within` card was:

```tsx
<BorderAnimate trigger="focus-within" borderWidth="sm" radius="sm">
  <TextInput w={190} placeholder="Click into the field" label='trigger="focus-within"' />
</BorderAnimate>
```

Its two sibling cards are a `Paper` with a `<Text>` caption. So this one used a form `label` as a caption, which put the animated border around caption + field, with a `radius="sm"` tracing neither. It also contradicted the paragraph #33 added to `docs.mdx` on the very same page.

## The change

```tsx
<BorderAnimate trigger="focus-within" borderWidth="sm">
  <Paper radius="md" p="md" w={190}>
    <Text fw={600}>trigger="focus-within"</Text>
    <Input mt="xs" placeholder="Click into the field" />
  </Paper>
</BorderAnimate>
```

Here the border wrapping the whole card is the *right* thing — the demo is about decorating a card, and all three should look alike. The guidance from #33 is about decorating a field, which is what the Input Fields demo does.

## Measured

| Check | Result |
|---|---|
| The three cards | **190x128** each, Paper **190x128** each |
| Any `<label>` left in the demo | **none** |
| `focus-within` still latches | **yes** — focusing the input puts the root in `:focus-within` |

## Test plan
- [x] `yarn test` passes
- [x] `yarn docs:build` passes with `docs/.next` removed first
- [x] Card geometry and `:focus-within` measured in Chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `focus-within` border animation demo with a clearer panel layout.
  * Replaced the labeled text input with a standard input field and added a visible title.
  * Simplified the demo’s border styling for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->